### PR TITLE
Upgrade messenger

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ node_js:
 - stable
 
 before_script:
-  - ./node_modules/travis-multirunner/setup.sh
   - export DISPLAY=:99.0
   - sh -e /etc/init.d/xvfb start
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,18 @@
+sudo: false
+language: node_js
+node_js:
+- 0.10
+- 4.1
+- stable
+
+before_script:
+  - ./node_modules/travis-multirunner/setup.sh
+  - export DISPLAY=:99.0
+  - sh -e /etc/init.d/xvfb start
+
+after_failure:
+  - for file in *.log; do echo $file; echo "======================"; cat $file; done || true
+
+notifications:
+  email:
+  - nathan.oehlman@nicta.com.au

--- a/README.md
+++ b/README.md
@@ -7,7 +7,9 @@ instances.
 
 [![NPM](https://nodei.co/npm/rtc-switchboard-messenger.png)](https://nodei.co/npm/rtc-switchboard-messenger/)
 
-[![unstable](https://img.shields.io/badge/stability-unstable-yellowgreen.svg)](https://github.com/dominictarr/stability#unstable) 
+[![unstable](https://img.shields.io/badge/stability-unstable-yellowgreen.svg)](https://github.com/dominictarr/stability#unstable)
+
+[![Build Status](https://img.shields.io/travis/rtc-io//rtc-switchboard-messenger.svg?branch=master)](https://travis-ci.org/rtc-io/rtc-switchboard-messenger)
 
 
 ## License(s)

--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@ instances.
 
 [![Build Status](https://img.shields.io/travis/rtc-io//rtc-switchboard-messenger.svg?branch=master)](https://travis-ci.org/rtc-io/rtc-switchboard-messenger)
 
+## Important Note
+
+With the 3.0 release, the `bufferutil` and `utf-8-validate` packages are no longer included by default in either `messenger-ws` or `rtc-switchboard-messenger`. These are recommended and should be included if your use case requires it.
 
 ## License(s)
 

--- a/package.json
+++ b/package.json
@@ -24,6 +24,6 @@
   "homepage": "https://github.com/rtc-io/rtc-switchboard-messenger",
   "dependencies": {
     "cog": "^1.0.0",
-    "messenger-ws": "^2.0.2"
+    "messenger-ws": "^3.0.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A specialised messenger-ws implementation that knows how to connect to a rtc-switchboard instance",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "node test/all.js",
     "gendocs": "gendocs > README.md"
   },
   "repository": {
@@ -25,5 +25,8 @@
   "dependencies": {
     "cog": "^1.0.0",
     "messenger-ws": "^3.0.1"
+  },
+  "devDependencies": {
+    "tape": "^4.4.0"
   }
 }

--- a/test/all.js
+++ b/test/all.js
@@ -1,0 +1,6 @@
+var test = require('tape');
+
+test('import messenger', function(t) {
+	t.plan(1);
+	t.ok(require('..'));
+});


### PR DESCRIPTION
Upgrades to ws-messenger `^3.0.1`. 

Adds a simple test to test installation on different versions of Node.

Adds a warning message to the readme about `bufferutil` and `utf-8-validate` no longer being included by default.
