### PR TITLE
Make work with browserify when optional packages not included

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,14 @@ node_js:
 - 4.1
 - stable
 
+env:
+  matrix:
+    - BROWSER=chrome  BVER=stable
+    - BROWSER=firefox BVER=stable
+
+matrix:
+  fast_finish: true
+
 before_script:
   - export DISPLAY=:99.0
   - sh -e /etc/init.d/xvfb start

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ matrix:
   fast_finish: true
 
 before_script:
+  - ./node_modules/travis-multirunner/setup.sh
   - export DISPLAY=:99.0
   - sh -e /etc/init.d/xvfb start
 

--- a/build.js
+++ b/build.js
@@ -1,0 +1,14 @@
+var through = require('through2');
+var viralify = require('viralify');
+var transformed = false;
+
+module.exports = function(file) {
+	if (transformed) return through();
+	try {
+		viralify.sync(__dirname, ['ws'], 'browserify-optional', true);
+		transformed = true;
+	} catch (e) {
+		console.error('Failed to correctly handle optional dependencies in ws');
+	}
+	return through();
+};

--- a/package.json
+++ b/package.json
@@ -24,19 +24,22 @@
   },
   "homepage": "https://github.com/rtc-io/rtc-switchboard-messenger",
   "dependencies": {
-    "browserify-optional": "^1.0.0",
     "cog": "^1.0.0",
-    "messenger-ws": "^3.0.1",
-    "through2": "^2.0.0",
-    "viralify": "^0.4.2"
+    "messenger-ws": "^3.0.1"
   },
   "devDependencies": {
     "broth": "^2.2.0",
+    "browserify": "^12.0.1",
+    "browserify-optional": "^1.0.0",
     "tap-spec": "^4.1.1",
     "tape": "^4.4.0",
-    "travis-multirunner": "^3.0.0"
+    "through2": "^2.0.0",
+    "travis-multirunner": "^3.0.0",
+    "viralify": "^0.4.2"
   },
   "browserify": {
-    "transform": ["./build.js"]
+    "transform": [
+      "./build.js"
+    ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "A specialised messenger-ws implementation that knows how to connect to a rtc-switchboard instance",
   "main": "index.js",
   "scripts": {
-    "test": "node test/all.js",
+    "test": "node test/all.js && npm run test-browser",
+    "test-browser": "browserify test/all.js | broth ./node_modules/travis-multirunner/start.sh | tap-spec",
     "gendocs": "gendocs > README.md"
   },
   "repository": {
@@ -23,10 +24,19 @@
   },
   "homepage": "https://github.com/rtc-io/rtc-switchboard-messenger",
   "dependencies": {
+    "browserify-optional": "^1.0.0",
     "cog": "^1.0.0",
-    "messenger-ws": "^3.0.1"
+    "messenger-ws": "^3.0.1",
+    "through2": "^2.0.0",
+    "viralify": "^0.4.2"
   },
   "devDependencies": {
-    "tape": "^4.4.0"
+    "broth": "^2.2.0",
+    "tap-spec": "^4.1.1",
+    "tape": "^4.4.0",
+    "travis-multirunner": "^3.0.0"
+  },
+  "browserify": {
+    "transform": ["./build.js"]
   }
 }


### PR DESCRIPTION
The updates to `ws` and `messenger-ws` have left this as failing when browserifying when `utf-8-validate` and `bufferutil` are not included (which would defeat the purpose of them being optional).

Updates to use a `browserify-optional` transform to force `ws` optional includes (`try..catch`) to work with browserify.
